### PR TITLE
Добавлен вариант использования go-chi/render в качестве библиотеки для работы с JSON endpoint

### DIFF
--- a/cmd/shortenertest/iteration4_test.go
+++ b/cmd/shortenertest/iteration4_test.go
@@ -36,6 +36,7 @@ func (suite *Iteration4Suite) SetupSuite() {
 		"encoding/json",
 		"github.com/mailru/easyjson",
 		"github.com/pquerna/ffjson",
+		"github.com/go-chi/render",
 	}
 
 	suite.serverAddress = "http://localhost:8080"


### PR DESCRIPTION
В рамках третьего спринта при работе с go-chi от наставника Дениса Алексеева был совет реализовывать rest-endpoint по примеру из библиотеки (https://github.com/go-chi/chi/blob/master/_examples/rest/main.go). Соответственно, преобразование запроса в объект и обратно было переведено в go-chi/render (который в свою очередь использует encoding/json).

Предлагаю добавить еще один вариант для проверки использования библиотеки JSON в тест. Т.к. текущее поведение теста (ошибка Не найдено использование известных библиотек кодирования JSON) не стыкуется с рекоммендациями наставника. Приходится делать workaround с добавлением неиспользуемого кода с нужной для теста зависимостью.