### PR TITLE
Iter17 fix

### DIFF
--- a/cmd/shortenertest/iteration17_test.go
+++ b/cmd/shortenertest/iteration17_test.go
@@ -143,7 +143,7 @@ func undocumentedGenDecl(decl *ast.GenDecl) bool {
 			}
 		case *ast.ValueSpec:
 			for _, name := range st.Names {
-				if name.IsExported() && decl.Doc == nil {
+				if name.IsExported() && (st.Doc == nil && decl.Doc == nil) {
 					return true
 				}
 			}

--- a/cmd/shortenertest/iteration17_test.go
+++ b/cmd/shortenertest/iteration17_test.go
@@ -138,7 +138,7 @@ func undocumentedGenDecl(decl *ast.GenDecl) bool {
 	for _, spec := range decl.Specs {
 		switch st := spec.(type) {
 		case *ast.TypeSpec:
-			if st.Name.IsExported() && decl.Doc == nil {
+			if st.Name.IsExported() && (st.Doc == nil && decl.Doc == nil) {
 				return true
 			}
 		case *ast.ValueSpec:

--- a/cmd/shortenertest/iteration17_test.go
+++ b/cmd/shortenertest/iteration17_test.go
@@ -138,12 +138,12 @@ func undocumentedGenDecl(decl *ast.GenDecl) bool {
 	for _, spec := range decl.Specs {
 		switch st := spec.(type) {
 		case *ast.TypeSpec:
-			if st.Name.IsExported() && (st.Doc == nil && decl.Doc == nil) {
+			if st.Name.IsExported() && st.Doc == nil && decl.Doc == nil {
 				return true
 			}
 		case *ast.ValueSpec:
 			for _, name := range st.Names {
-				if name.IsExported() && (st.Doc == nil && decl.Doc == nil) {
+				if name.IsExported() && st.Doc == nil && decl.Doc == nil {
 					return true
 				}
 			}


### PR DESCRIPTION
Fix the documentation check for types and variables declared through the code block:

```
type (
  // SomeTypeStr implements some string type.
  SomeTypeStr string

  // SomeTypeInt implements some int type.
  SomeTypeInt int
)
```