### PR TITLE
test: 'github.com/goccy/go-json' added to known encoding libs

### DIFF
--- a/cmd/devopstest/iteration4_test.go
+++ b/cmd/devopstest/iteration4_test.go
@@ -51,6 +51,7 @@ func (suite *Iteration4Suite) SetupSuite() {
 		"encoding/json",
 		"github.com/mailru/easyjson",
 		"github.com/pquerna/ffjson",
+		"github.com/goccy/go-json",
 	}
 
 	suite.serverAddress = "http://localhost:8080"


### PR DESCRIPTION
Список возможных для использования json пакетов представляется ограниченным. Это нормально на 4-м инкременте, но проблема в том, что тест будет проверяться и позже. В 15-м инкременте, например, мы используем профилировщик pprof и оптимизируем приложение - здесь пакет "github.com/goccy/go-json" (или его аналоги) мог бы пригодиться. 
Возможно стоит добавить и другие пакеты.