### PR TITLE
add content types to requests

### DIFF
--- a/cmd/metricstest/iteration12_test.go
+++ b/cmd/metricstest/iteration12_test.go
@@ -210,7 +210,8 @@ func (suite *Iteration12Suite) TestBatchAPI() {
 			},
 		}
 
-		req := httpc.R()
+		req := httpc.R().
+			SetHeader("Content-Type", "application/json")
 		resp, err := req.SetBody(metrics).
 			Post("updates/")
 

--- a/cmd/metricstest/iteration1_test.go
+++ b/cmd/metricstest/iteration1_test.go
@@ -92,7 +92,8 @@ func (suite *Iteration1Suite) TestGaugeHandlers() {
 	httpc := resty.New().SetHostURL(suite.serverAddress)
 
 	suite.Run("update", func() {
-		req := httpc.R()
+		req := httpc.R().
+			SetHeader("Content-Type", "plain/text")
 		resp, err := req.Post("update/gauge/testGauge/100")
 
 		noRespErr := suite.Assert().NoError(err,
@@ -108,7 +109,8 @@ func (suite *Iteration1Suite) TestGaugeHandlers() {
 	})
 
 	suite.Run("without id", func() {
-		req := httpc.R()
+		req := httpc.R().
+			SetHeader("Content-Type", "plain/text")
 		resp, err := req.Post("update/gauge/")
 
 		noRespErr := suite.Assert().NoError(err,
@@ -124,7 +126,8 @@ func (suite *Iteration1Suite) TestGaugeHandlers() {
 	})
 
 	suite.Run("invalid value", func() {
-		req := httpc.R()
+		req := httpc.R().
+			SetHeader("Content-Type", "plain/text")
 		resp, err := req.Post("update/gauge/testGauge/none")
 
 		noRespErr := suite.Assert().NoError(err,
@@ -144,7 +147,8 @@ func (suite *Iteration1Suite) TestCounterHandlers() {
 	httpc := resty.New().SetHostURL(suite.serverAddress)
 
 	suite.Run("update", func() {
-		req := httpc.R()
+		req := httpc.R().
+			SetHeader("Content-Type", "plain/text")
 		resp, err := req.Post("update/counter/testCounter/100")
 
 		noRespErr := suite.Assert().NoError(err,
@@ -160,7 +164,8 @@ func (suite *Iteration1Suite) TestCounterHandlers() {
 	})
 
 	suite.Run("without id", func() {
-		req := httpc.R()
+		req := httpc.R().
+			SetHeader("Content-Type", "plain/text")
 		resp, err := req.Post("update/counter/")
 
 		noRespErr := suite.Assert().NoError(err,
@@ -176,7 +181,8 @@ func (suite *Iteration1Suite) TestCounterHandlers() {
 	})
 
 	suite.Run("invalid value", func() {
-		req := httpc.R()
+		req := httpc.R().
+			SetHeader("Content-Type", "plain/text")
 		resp, err := req.Post("update/counter/testCounter/none")
 
 		noRespErr := suite.Assert().NoError(err,
@@ -196,7 +202,8 @@ func (suite *Iteration1Suite) TestUnknownHandlers() {
 	httpc := resty.New().SetHostURL(suite.serverAddress)
 
 	suite.Run("update invalid type", func() {
-		req := httpc.R()
+		req := httpc.R().
+			SetHeader("Content-Type", "plain/text")
 		resp, err := req.Post("update/unknown/testCounter/100")
 
 		noRespErr := suite.Assert().NoError(err,
@@ -212,7 +219,8 @@ func (suite *Iteration1Suite) TestUnknownHandlers() {
 	})
 
 	suite.Run("update invalid method", func() {
-		req := httpc.R()
+		req := httpc.R().
+			SetHeader("Content-Type", "plain/text")
 		resp, err := req.Post("updater/counter/testCounter/100")
 
 		noRespErr := suite.Assert().NoError(err,

--- a/cmd/shortenertestbeta/iteration11_test.go
+++ b/cmd/shortenertestbeta/iteration11_test.go
@@ -107,6 +107,7 @@ func (suite *Iteration11Suite) TestInspectDatabase() {
 
 		req := httpc.R().
 			SetContext(ctx).
+			SetHeader("Content-Type", "plain/text").
 			SetBody(originalURL)
 		_, err := req.Post("/")
 		noRespErr := suite.Assert().NoError(err, "Ошибка при попытке сделать запрос для сокращения URL")

--- a/cmd/shortenertestbeta/iteration13_test.go
+++ b/cmd/shortenertestbeta/iteration13_test.go
@@ -147,6 +147,7 @@ func (suite *Iteration13Suite) TestConflict() {
 
 			req := httpc.R().
 				SetContext(ctx).
+				SetHeader("Content-Type", "plain/text").
 				SetBody(originalURL)
 			resp, err := req.Post("/")
 

--- a/cmd/shortenertestbeta/iteration14_test.go
+++ b/cmd/shortenertestbeta/iteration14_test.go
@@ -112,6 +112,7 @@ func (suite *Iteration14Suite) TestAuth() {
 
 		req := httpc.R().
 			SetContext(ctx).
+			SetHeader("Content-Type", "plain/text").
 			SetBody(originalURL)
 		resp, err := req.Post("/")
 

--- a/cmd/shortenertestbeta/iteration15_test.go
+++ b/cmd/shortenertestbeta/iteration15_test.go
@@ -162,6 +162,7 @@ func (suite *Iteration15Suite) TestDelete() {
 
 			req := httpc.R().
 				SetContext(ctx).
+				SetHeader("Content-Type", "plain/text").
 				SetBody(originalURL)
 			resp, err := req.Post("/")
 
@@ -287,6 +288,7 @@ func (suite *Iteration15Suite) TestDeleteConcurrent() {
 
 			req := httpc.R().
 				SetContext(ctx).
+				SetHeader("Content-Type", "plain/text").
 				SetBody(originalURL)
 			resp, err := req.Post("/")
 

--- a/cmd/shortenertestbeta/iteration1_test.go
+++ b/cmd/shortenertestbeta/iteration1_test.go
@@ -116,6 +116,7 @@ func (suite *Iteration1Suite) TestHandlers() {
 		// делаем запрос к серверу для сокращения URL
 		req := httpc.R().
 			SetContext(ctx).
+			SetHeader("Content-Type", "plain/text").
 			SetBody(originalURL)
 		resp, err := req.Post("/")
 

--- a/cmd/shortenertestbeta/iteration4_test.go
+++ b/cmd/shortenertestbeta/iteration4_test.go
@@ -100,6 +100,7 @@ func (suite *Iteration4Suite) TestFlags() {
 
 		req := httpc.R().
 			SetContext(ctx).
+			SetHeader("Content-Type", "plain/text").
 			SetBody(originalURL)
 		resp, err := req.Post("/")
 

--- a/cmd/shortenertestbeta/iteration5_test.go
+++ b/cmd/shortenertestbeta/iteration5_test.go
@@ -136,6 +136,7 @@ func (suite *Iteration5Suite) TestEnvVars() {
 
 		req := httpc.R().
 			SetContext(ctx).
+			SetHeader("Content-Type", "plain/text").
 			SetBody(originalURL)
 		resp, err := req.Post("/")
 

--- a/cmd/shortenertestbeta/iteration8_test.go
+++ b/cmd/shortenertestbeta/iteration8_test.go
@@ -119,6 +119,7 @@ func (suite *Iteration8Suite) TestGzipCompress() {
 		req := httpc.R().
 			SetContext(ctx).
 			SetBody(buf.Bytes()).
+			SetHeader("Content-Type", "plain/text").
 			SetHeader("Accept-Encoding", "gzip").
 			SetHeader("Content-Encoding", "gzip")
 		resp, err := req.Post("/")

--- a/cmd/shortenertestbeta/iteration9_test.go
+++ b/cmd/shortenertestbeta/iteration9_test.go
@@ -90,6 +90,7 @@ func (suite *Iteration9Suite) TestPersistentFile() {
 	suite.Run("shorten", func() {
 		req := httpc.R().
 			SetContext(ctx).
+			SetHeader("Content-Type", "plain/text").
 			SetBody(originalURL)
 		resp, err := req.Post("/")
 


### PR DESCRIPTION
### Проблема
В задании написано что для сокращения ссылок необходимо отправить plain-text
Студенты решили дополнительно проверить content-type и оказалось что он не передается
Считаю что их решение хоть и не обязательно, но вполне валидно и похвально. Поэтому правильно будет соответствовать заданию и добавить соответствующие хедеры