### PR TITLE
shortenertest iter12 fix

### DIFF
--- a/cmd/shortenertest/iteration12_test.go
+++ b/cmd/shortenertest/iteration12_test.go
@@ -221,7 +221,7 @@ func (suite *Iteration12Suite) TestBatchShorten() {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
 
-			req := resty.New().
+			req := httpc.
 				SetRedirectPolicy(redirPolicy).
 				R()
 			resp, err := req.


### PR DESCRIPTION
Создается чистый Resty, в нем нет бейзурла, оттого и ошибки вида "unsupported protocol scheme"