### PR TITLE
fix not found src for check database/sql import in shortentestbeta iter10

### DIFF
--- a/cmd/shortenertestbeta/flags.go
+++ b/cmd/shortenertestbeta/flags.go
@@ -20,7 +20,7 @@ var (
 
 func init() {
 	flag.StringVar(&flagTargetBinaryPath, "binary-path", "", "path to target HTTP server binary")
-	flag.StringVar(&flagTargetSourcePath, "source-path", "", "path to target HTTP server source")
+	flag.StringVar(&flagTargetSourcePath, "source-path", ".", "path to target HTTP server source")
 	flag.StringVar(&flagServerHost, "server-host", "", "host of target HTTP address")
 	flag.StringVar(&flagServerPort, "server-port", "", "port of target HTTP address")
 	flag.StringVar(&flagServerBaseURL, "server-base-url", "", "base URL of target HTTP address")

--- a/cmd/shortenertestbeta/iteration10_test.go
+++ b/cmd/shortenertestbeta/iteration10_test.go
@@ -97,7 +97,7 @@ func (suite *Iteration10Suite) TearDownSuite() {
 
 // TestLibraryUsage пробует рекурсивно найти использование database/sql хотя бы в одном файле с исходным кодом проекта
 func (suite *Iteration10Suite) TestLibraryUsage() {
-	err := usesKnownPackage(suite.T(), ".", suite.knownLibraries)
+	err := usesKnownPackage(suite.T(), flagTargetSourcePath, suite.knownLibraries)
 	if err == nil {
 		return
 	}


### PR DESCRIPTION
Тесты не проходили локально на машине, в гитхабе было все окей. Полез в тесты и нашел опечатку, тест (shortentestbeta/iteration10_test.go/TestLibraryUsage) всегда ищет использование database/sql в корне, а не в flagTargetSourcePath.