### PR TITLE
Fix for tables with foreign keys

### DIFF
--- a/cmd/wipedb/main.go
+++ b/cmd/wipedb/main.go
@@ -43,7 +43,7 @@ func run() error {
 	}
 
 	for _, tableName := range tables {
-		_, err = db.ExecContext(ctx, `DROP TABLE `+tableName)
+		_, err = db.ExecContext(ctx, `DROP TABLE `+tableName+` CASCADE`)
 		if err != nil {
 			return fmt.Errorf("cannot perform table wipe: %w", err)
 		}


### PR DESCRIPTION
Упал [тест](https://github.com/kuznet1/urlshrt/actions/runs/17279650116/job/49045035220) потому что в таблице есть внешний ключ и утилита не смогла удалить таблицы